### PR TITLE
Allow jvcprojectortools to be imported into other Python modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,24 @@
 Scripts to send commands 2015 model JVC D-ILA Projectors.
 
 ## Prerequisites
-- Python [3.6](https://www.python.org/downloads/release/python-360/) or [later](https://www.python.org/downloads/) installed
+- Python [3.6](https://www.python.org/downloads/release/python-360/) or [later](https://www.python.org/downloads/) installed (most functionality except the gamma functionality works with Python 2.7, provided the `enum34` package is installed)
 - Network connected JVC projector
 
 ## Quick start
-Run menu.py, enter "1" for "Setup HDR" and follow the on-screen instructions.
+### Running from menu
+To run using the menu interface, run menu.py, enter "1" for "Setup HDR" and follow the on-screen instructions.
+
+### Using as a library
+Elements of the `jvcprojectortools` project can also be reused by other Python code.  The `host_port_str` parameter must be specified when instantiating a JVCCommand object.  A simple example of this is shown below:
+```python
+from jvcprojectortools.jvc_command import(JVCCommand, Command)
+host_port_str = '192.168.9.2:20554'
+jvc_projector = JVCCommand(host_port_str=host_port_str)
+jvc_projector.__enter__()
+power = jvc_projector.get(Command.Power)
+print(power)
+jvc_projector.conn.conn.close()
+```
 
 ## Main Menu
 The menu lists the commands you can enter on the left and a description on the right. Some commands accepts optional arguments. These arguments are listed as [argument] in the description. Multiple commands can be run if separated by ";"
@@ -90,7 +103,7 @@ Set the input brightness where the curve will stop following the eotf curve and 
 Set to a value between 0 and 1 to shape the soft-clip curve. The angle of the curve at the end point can move from horizontal (1) to pointing at the soft-clip start point (0). The curve a the start of the soft-clip start point always points in the same direction as the eotf curve at that point, but as the end-slope value gets smaller this part of the curve gets less and less weight.
 
 ### Set soft clip curve type
-Selects between a cubic Bézier curve (0) and quadratic Bézier curve (1). 0 gives more weight to the angle at the start and end points, and will deviate less from the eotf curve at the start.
+Selects between a cubic Bï¿½zier curve (0) and quadratic Bï¿½zier curve (1). 0 gives more weight to the angle at the start and end points, and will deviate less from the eotf curve at the start.
 
 ### Set soft clip gamma
 Selects the gamma to draw the soft clip curve in.

--- a/jvc_network.py
+++ b/jvc_network.py
@@ -23,11 +23,12 @@ class Timeout(Exception):
 
 class JVCNetwork:
     """JVC projector network connection"""
-    def __init__(self, print_all=False, print_recv=False, print_send=False):
+    def __init__(self, host_port_str=None, print_all=False, print_recv=False, print_send=False):
         self.print_recv = print_recv or print_all
         self.print_send = print_send or print_all
-        self.socket = None
+        self.host_port_str = host_port_str
         self.host_port = None
+        self.socket = None
 
     def connect(self):
         """Open network connection to projector and perform handshake"""
@@ -53,20 +54,24 @@ class JVCNetwork:
         save_conf = False
 
         while True:
-            if not conf.get('host', None):
-                print('\nIf you have configured a hostname for your projector (usually in your\n'
-                      'internet gateway) enter that hostname here.\n'
-                      'If you don'"'"'t have a hostname, you can use the "IP Address" displayed \n'
-                      'in the "Network" menu (found under the "Function" main menu) on the\n'
-                      'projector. If "DHCP Client" is "Off" change it to "On" then select "Set"\n'
-                      'to have the "IP Address" information filled out.\n')
-                conf['host'] = input('Enter hostname or ip address: ')
-                save_conf = True
+            if isinstance(self.host_port_str, str):
+                conf = dict()
+                conf['host'] = self.host_port_str.split(':')[0]
+                conf['port'] = int(self.host_port_str.split(':')[1])
+            else:
+                if not conf.get('host', None):
+                    print('\nIf you have configured a hostname for your projector (usually in your\n'
+                          'internet gateway) enter that hostname here.\n'
+                          'If you don'"'"'t have a hostname, you can use the "IP Address" displayed \n'
+                          'in the "Network" menu (found under the "Function" main menu) on the\n'
+                          'projector. If "DHCP Client" is "Off" change it to "On" then select "Set"\n'
+                          'to have the "IP Address" information filled out.\n')
+                    conf['host'] = input('Enter hostname or ip address: ')
+                    save_conf = True
 
-            if not conf.get('port', None):
-                conf['port'] = 20554
-                save_conf = True
-
+                if not conf.get('port', None):
+                    conf['port'] = 20554
+                    save_conf = True
             try:
                 self.host_port = (conf['host'], conf['port'])
                 self.connect()


### PR DESCRIPTION
This modification allows the host and port to be specified when when instantiating a JVCCommand object, which allows jvcprojectortools to be reused by other Python modules without having to use a config file.  My motivation for doing this is that I want to use jvcprojectortools as part of an EventGhost plug-in to control a JVC projector, and require this functionality to do so.